### PR TITLE
test: add CLI entry-point exposure tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,11 @@ test-full = "pytest tests/ -m 'root or not root'"
 # Unit tests + Multiprocessing check + ROOT check
 test-matrix = "pytest tests/unit/ --junitxml=test-results-matrix-unit.xml && combine_postfits -i tests/fitDiags/fit_diag_A.root -o tests/matrix_out -p 2 --data --unblind && pytest tests/ -m root --junitxml=test-results-matrix-root.xml"
 
+# TASK 6: CLI entry-point exposure tests
+# Verifies executables are installed and on PATH
+# Use for: Validating packaging after install
+test-cli = "pytest tests/test_cli_exposure.py -v"
+
 [feature.py310.dependencies]
 python = "3.10.*"
 

--- a/tests/test_cli_exposure.py
+++ b/tests/test_cli_exposure.py
@@ -1,0 +1,53 @@
+"""
+Tests that CLI entry points are properly installed and accessible.
+
+These tests are environment-agnostic: they work whether the package was
+installed via pip, pixi, conda, or any other method. They verify that the
+currently active environment exposes the expected console scripts.
+"""
+
+import importlib.metadata
+import shutil
+import subprocess
+
+import pytest
+
+CONSOLE_SCRIPTS = ["combine_postfits", "combine_postfits_cov"]
+
+
+@pytest.mark.parametrize("name", CONSOLE_SCRIPTS)
+def test_entry_point_registered(name):
+    """Verify that the entry point is declared in package metadata."""
+    eps = importlib.metadata.entry_points()
+    # Python 3.12+ returns a SelectableGroups; 3.9–3.11 returns a dict
+    if hasattr(eps, "select"):
+        console_scripts = eps.select(group="console_scripts")
+    else:
+        console_scripts = eps.get("console_scripts", [])
+    registered_names = [ep.name for ep in console_scripts]
+    assert name in registered_names, (
+        f"'{name}' not found in console_scripts entry points. Registered: {registered_names}"
+    )
+
+
+@pytest.mark.parametrize("name", CONSOLE_SCRIPTS)
+def test_executable_on_path(name):
+    """Verify that the executable is findable on $PATH."""
+    location = shutil.which(name)
+    assert location is not None, f"'{name}' not found on $PATH. Make sure the package is installed (pip install -e .)."
+
+
+@pytest.mark.parametrize("name", CONSOLE_SCRIPTS)
+def test_executable_runs(name):
+    """Verify that the executable launches and prints help."""
+    result = subprocess.run(
+        [name, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"'{name} --help' exited with code {result.returncode}.\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )


### PR DESCRIPTION
Add tests/test_cli_exposure.py with three layers of validation:
- Entry-point metadata registration (importlib.metadata)
- Executable on PATH (shutil.which)
- Executable launches cleanly (subprocess --help)

Parametrized over both combine_postfits and combine_postfits_cov.
Also adds test-cli task to pixi.toml.
