### PR TITLE
chore: remove commented-out matplotlib.use in plot_cov.py

### DIFF
--- a/src/combine_postfits/plot_cov.py
+++ b/src/combine_postfits/plot_cov.py
@@ -3,8 +3,6 @@ from typing import List, Optional, Union
 
 import hist
 import matplotlib
-
-# matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import mplhep as hep
 import numpy as np


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed a commented-out `matplotlib.use("Agg")` line in `src/combine_postfits/plot_cov.py`.

💡 **Why:** How this improves maintainability
Removing dead code reduces clutter and improves readability. The Backend is already set in the `main()` function of the same file, making the commented-out top-level call redundant.

✅ **Verification:** How you confirmed the change is safe
- Verified the code passes `ruff check` and `ruff format --check`.
- Manual inspection of the code confirms the removal is safe as the functionality is preserved by the identical call in `main()`.

✨ **Result:** The improvement achieved
Cleaner, more maintainability code by removing obsolete comments.

---
*PR created automatically by Jules for task [15028250201635219074](https://jules.google.com/task/15028250201635219074) started by @andrzejnovak*