### PR TITLE
⚡ Bolt: Optimize histogram max calculation in plot_postfits

### DIFF
--- a/src/combine_postfits/plot_postfits.py
+++ b/src/combine_postfits/plot_postfits.py
@@ -138,13 +138,18 @@ def plot(
             logging.warning(f"  Hist '{key}' is missing and will be ignored. Available keys are: {hist_keys}")
 
     # Soft-fail on missing hist
+    # Pre-calculate global max to avoid O(N) lookup in loop
+    if len(hist_dict) > 0:
+        _max_value_global = np.max([np.max(h.values()) for h in hist_dict.values()])
+    else:
+        _max_value_global = 1.0
+
     def hist_dict_fcn(name, raw=False, global_scale=True, th=0.003):
         """
         raw: return raw hist without any modifications
         global_scale: when true will clip small values based on global max, else based on hist max
                 set to False when plotting eg. signal in ratio
         """
-        _max_value_global = np.max([np.max(h.values()) for h in hist_dict.values()])
         if name not in hist_dict:
             logging.warning(f"  Hist '{name}' is missing. Will be replaced with zeros.")
             _hobj = deepcopy(hist_dict[list(hist_dict.keys())[0]])


### PR DESCRIPTION
💡 What: Hoisted `_max_value_global` calculation out of `hist_dict_fcn` in `src/combine_postfits/plot_postfits.py`.
🎯 Why: To avoid redundant O(K) iteration over all histograms for every histogram plotted/processed (O(N) calls).
📊 Impact: Reduces computational complexity of the plotting loop. While end-to-end benchmark showed minimal wall-time improvement due to `matplotlib` dominance, the logic is now more efficient and scalable for large numbers of histograms.
🔬 Measurement: Verified with `benchmark.py` (simulating `plots_A` case) and `pytest tests/unit`.

---
*PR created automatically by Jules for task [10946921070915203417](https://jules.google.com/task/10946921070915203417) started by @andrzejnovak*