### PR TITLE
⚡ Bolt: Optimize metric computation with single-pass Uproot extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+## 2024-06-25 - Optimize metric computation with single-pass Uproot extraction
+**Learning:** In `make_style_dict_yaml`, computing metrics like yield and linearity using key-driven, top-down path lookups is extremely slow for large ROOT files. Converting Uproot objects to histograms via `to_hist()` is computationally expensive; batch processing or caching these conversions significantly improves performance when calculating multiple metrics per sample.
+**Action:** The optimal pattern is directory-driven: iterate through available Uproot directories, parse valid sample keys, extract objects, call `.to_hist()` exactly once, and compute all metrics simultaneously in a single pass.

--- a/src/combine_postfits/utils.py
+++ b/src/combine_postfits/utils.py
@@ -166,33 +166,31 @@ def make_style_dict_yaml(fitDiag, cmap="tab10", sort=True, sort_peaky=False):
         residuals = abs(fy - _h) / np.sqrt(_h)
         return np.sum(np.nan_to_num(residuals, posinf=0, neginf=0))
 
-    yield_dict = {
-        k: sum(
-            [
-                sum(fitDiag[f"shapes_{fit}/{ch}/{k}"].to_hist().values())
-                for fit in avail_fit_types
-                for ch in avail_channels
-                if f"shapes_{fit}/{ch}/{k}" in fitDiag
-                and hasattr(fitDiag[f"shapes_{fit}/{ch}/{k}"], "to_hist")
-                and "total" not in k  # Sum only TH1s, data is black anyway
-            ]
-        )
-        for k in sample_keys
-    }
-    linearity_dict = {
-        k: np.mean(
-            [
-                linearity(fitDiag[f"shapes_{fit}/{ch}/{k}"].to_hist())
-                for fit in avail_fit_types
-                for ch in avail_channels
-                if f"shapes_{fit}/{ch}/{k}" in fitDiag
-                and hasattr(fitDiag[f"shapes_{fit}/{ch}/{k}"], "to_hist")
-                and "total" not in k  # Sum only TH1s, data is black anyway
-            ]
-            + [0]  # pad 0 to prevent mean on empty list
-        )
-        for k in sample_keys
-    }
+    yield_dict = {k: 0 for k in sample_keys}
+    linearity_lists = {k: [] for k in sample_keys}
+
+    for fit in avail_fit_types:
+        for ch in avail_channels:
+            ch_path = f"shapes_{fit}/{ch}"
+            if ch_path not in fitDiag:
+                continue
+            ch_dir = fitDiag[ch_path]
+            # Uproot keys often have cycle numbers, e.g., 'name;1'
+            parsed_keys = {}
+            for full_k in ch_dir.keys():
+                base_k = full_k.split(";")[0]
+                if base_k not in parsed_keys:
+                    parsed_keys[base_k] = full_k
+
+            for k in sample_keys:
+                if k in parsed_keys and "total" not in k:
+                    obj = ch_dir[parsed_keys[k]]
+                    if hasattr(obj, "to_hist"):
+                        h = obj.to_hist()
+                        yield_dict[k] += sum(h.values())
+                        linearity_lists[k].append(linearity(h))
+
+    linearity_dict = {k: np.mean(linearity_lists[k] + [0]) for k in sample_keys}
     sort_score_dicts = {}
     for k, v in yield_dict.items():
         if sort_peaky:


### PR DESCRIPTION
💡 **What**: Refactored `make_style_dict_yaml` to compute both `yield` and `linearity` in a single pass through the Uproot directories. Extracted the histogram via `to_hist()` only once per sample object instead of twice, and eliminated redundant top-down dictionary lookups.

🎯 **Why**: In `make_style_dict_yaml`, computing metrics using key-driven, top-down path lookups (`f"shapes_{fit}/{ch}/{k}" in fitDiag`) within separate list comprehensions for yield and linearity meant that Uproot's `.to_hist()` was called multiple times for the same object. `to_hist()` is computationally expensive, making this a severe performance bottleneck for large ROOT files with many samples and channels.

📊 **Impact**: Reduces Uproot extraction and `.to_hist()` conversion overhead by roughly 50% during style dictionary generation. Eliminates `O(N)` redundant dictionary path lookups.

🔬 **Measurement**: Run the script on a large fitDiagnostics ROOT file and measure the time spent in `make_style_dict_yaml`.

_Also added an entry to `.jules/bolt.md` documenting this optimization pattern._

---
*PR created automatically by Jules for task [7600225105968505162](https://jules.google.com/task/7600225105968505162) started by @andrzejnovak*