### PR TITLE
⚡ Bolt: Replace np.polyfit with manual calculation for ~3x speedup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+
+## 2025-02-19 - Removed np.polyfit overhead for small arrays
+**Learning:** `np.polyfit` has significant overhead due to generalized routines (like SVD) and input validation. Using it in performance-critical loops on very small arrays (e.g., histogram bins) is extremely slow. Manual vectorized calculation of slope and intercept using `np.sum` is approximately 3x faster.
+**Action:** When performing simple 1D linear regression on small arrays in tight loops, prefer manual vectorized calculations over `np.polyfit` or `scipy.stats.linregress` to avoid large overheads.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+💡 What: Replaced np.polyfit with manual vectorized linear regression in the `linearity` function.
+🎯 Why: np.polyfit incurs significant overhead (e.g. SVD computation, shape checking) which is unnecessary for calculating linearity on small histogram arrays.
+📊 Impact: Expected ~3x performance improvement for the `linearity` calculations during sample sorting.
+🔬 Measurement: A benchmarking script `test_polyfit.py` confirmed manual vectorized linear regression using np.sum was ~3x faster. Unit tests were also successfully executed to verify correctness.

--- a/src/combine_postfits/utils.py
+++ b/src/combine_postfits/utils.py
@@ -154,16 +154,27 @@ def make_style_dict_yaml(fitDiag, cmap="tab10", sort=True, sort_peaky=False):
     # Sorting - yield/peakiness
     def linearity(h):
         _h = h.values()
-        x = np.arange(len(_h))
-        if len(_h) <= 1:
+        n = len(_h)
+        if n <= 1:
             return 0
-        try:
-            coef = np.polyfit(x, _h, 1)
-        except:  # noqa
+        x = np.arange(n)
+
+        # Manual linear regression is ~3x faster than np.polyfit for small arrays
+        sum_x = np.sum(x)
+        sum_y = np.sum(_h)
+        sum_x2 = np.sum(x * x)
+        sum_xy = np.sum(x * _h)
+
+        denominator = n * sum_x2 - sum_x**2
+        if denominator == 0:
             return 0
-        poly1d_fn = np.poly1d(coef)
-        fy = poly1d_fn(x)
-        residuals = abs(fy - _h) / np.sqrt(_h)
+
+        m = (n * sum_xy - sum_x * sum_y) / denominator
+        b = (sum_y - m * sum_x) / n
+        fy = m * x + b
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            residuals = np.abs(fy - _h) / np.sqrt(_h)
         return np.sum(np.nan_to_num(residuals, posinf=0, neginf=0))
 
     yield_dict = {


### PR DESCRIPTION
💡 What: Replaced np.polyfit with manual vectorized linear regression in the `linearity` function.
🎯 Why: np.polyfit incurs significant overhead (e.g. SVD computation, shape checking) which is unnecessary for calculating linearity on small histogram arrays.
📊 Impact: Expected ~3x performance improvement for the `linearity` calculations during sample sorting.
🔬 Measurement: A benchmarking script `test_polyfit.py` confirmed manual vectorized linear regression using np.sum was ~3x faster. Unit tests were also successfully executed to verify correctness.

---
*PR created automatically by Jules for task [10492330728058289912](https://jules.google.com/task/10492330728058289912) started by @andrzejnovak*