### PR TITLE
⚡ Bolt: Replace O(N^2) list flattening with O(N) set comprehension

### DIFF
--- a/src/combine_postfits/plot_postfits.py
+++ b/src/combine_postfits/plot_postfits.py
@@ -113,9 +113,7 @@ def plot(
     if len(channels) == 0:
         return None, (None, None)
     orig_hist_keys = [
-        k.split(";")[0]
-        for k in list(set(sum([c.keys() for c in channels], [])))
-        if "data" not in k and "covar" not in k
+        k.split(";")[0] for k in {k for c in channels for k in c.keys()} if "data" not in k and "covar" not in k
     ]
     data = getha("data", channels, restoreNorm=restoreNorm)
     hist_dict = geths(
@@ -192,7 +190,7 @@ def plot(
                 hist_keys.remove(key)
 
     # Fetch keys
-    if "total_signal" not in list(set(sum([c.keys() for c in channels], []))):  # no signal in CRs
+    if "total_signal" not in {k for c in channels for k in c.keys()}:  # no signal in CRs
         default_signal = []
     else:
         default_signal = [


### PR DESCRIPTION
💡 What: Replaced \`sum([c.keys() for c in channels], [])\` with \`{k for c in channels for k in c.keys()}\` when gathering unique keys from Uproot directories in \`src/combine_postfits/plot_postfits.py\`.
🎯 Why: The \`sum()\` pattern for flattening lists of lists executes in O(N^2) time due to repeatedly creating and destroying intermediate lists. Set comprehension executes in O(N) time and avoids these redundant memory allocations. Furthermore, it inherently handles deduplication, removing the need for the subsequent \`set()\` call.
📊 Impact: Significantly speeds up the aggregation of sample keys across multiple channels, specifically when plotting many categories or fits. Reduces memory overhead and garbage collection pauses within the core data preparation loop.
🔬 Measurement: Validated via the full test suite (\`pixi run test-full\`), confirming identical functionality and no regressions.

---
*PR created automatically by Jules for task [15012440147946726972](https://jules.google.com/task/15012440147946726972) started by @andrzejnovak*