### PR TITLE
⚡ Bolt: Replace strict list summations in multiprocessing tracking loops with generator short-circuiting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+
+## 2025-02-19 - Replace explicit summations inside loop tracking with `any` short-circuit checks.
+**Learning:** `sum([p.is_alive() for p in _procs])` loops strictly bounded O(N) allocation and summation in checking processes inside a long running while block. Use `any(p.is_alive() for p in _procs)` to use python generator behavior for quick O(1) performance inside infinite tracking loops.
+**Action:** Identify and replace existence checks that explicitly generate new lists or calculate strict integer summations in `while` loops for simple tracking purposes.

--- a/src/combine_postfits/make_plots.py
+++ b/src/combine_postfits/make_plots.py
@@ -703,7 +703,7 @@ def main():
                 p.start()
                 time.sleep(0.1)
 
-                n_running = sum([p.is_alive() for p in _procs])
+                n_running = sum(p.is_alive() for p in _procs)
                 progress.update(
                     prog_plotting,
                     completed=len(_procs) - n_running,
@@ -715,8 +715,8 @@ def main():
                 mod_plot()
                 progress.update(prog_plotting, advance=1, refresh=True)
         if args.multiprocessing > 0:
-            while sum([p.is_alive() for p in _procs]) > 0:
-                n_running = sum([p.is_alive() for p in _procs])
+            while any(p.is_alive() for p in _procs):
+                n_running = sum(p.is_alive() for p in _procs)
                 progress.update(
                     prog_plotting,
                     completed=len(_procs) - n_running,


### PR DESCRIPTION
💡 What: Swapped list-comprehension based summations with generator-based iterations inside the `make_plots.py` process-monitoring loop. In particular, replaced `while sum([p.is_alive() for p in _procs]) > 0` with `while any(p.is_alive() for p in _procs)`.

🎯 Why: To prevent expensive memory reallocation (`[]`) and bounded `O(N)` logic during every check of the process-monitoring loop. Instead of checking every process, `any()` short-circuits instantly upon finding the first running process, resulting in `O(1)` best-case evaluation. Also swapped the remaining `sum([...])` for process tracking to use generator expressions. 

📊 Impact: Reduces array allocations inside the busy tracking loop to zero, preventing O(N) allocation loops across N processes and saving unnecessary iterations.

🔬 Measurement: Run the test suite with multiprocessing enabled (e.g., `-p 10` on any large input) to observe tracking execution overhead differences, or simply review via `pixi run test` to verify equivalent logic.

---
*PR created automatically by Jules for task [1007799882958516488](https://jules.google.com/task/1007799882958516488) started by @andrzejnovak*