### PR TITLE
⚡ Bolt: replace O(N^2) list flattening with O(1) any() check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+
+## 2025-05-01 - Fast Dictionary Membership Check
+**Learning:** Flattening nested lists of dictionary keys via `sum(lists, [])` just to perform a boolean membership check incurs massive memory reallocation and O(N^2) time complexity.
+**Action:** Use short-circuiting generator expressions with `any(key in dict for dict in list_of_dicts)` which is both faster and uses O(1) memory.

--- a/src/combine_postfits/plot_postfits.py
+++ b/src/combine_postfits/plot_postfits.py
@@ -192,7 +192,8 @@ def plot(
                 hist_keys.remove(key)
 
     # Fetch keys
-    if "total_signal" not in list(set(sum([c.keys() for c in channels], []))):  # no signal in CRs
+    # ⚡ Bolt: Replaced O(N^2) sum([lists], []) flattening with O(1) memory, short-circuiting any() check
+    if not any("total_signal" in c for c in channels):  # no signal in CRs
         default_signal = []
     else:
         default_signal = [


### PR DESCRIPTION
💡 What: Replaced `if "total_signal" not in list(set(sum([c.keys() for c in channels], []))):` with `if not any("total_signal" in c for c in channels):`.
🎯 Why: Flattening nested lists of dictionary keys just to perform a boolean membership check incurs massive memory reallocation and O(N^2) time complexity.
📊 Impact: Uses a short-circuiting generator expression that runs in O(1) memory and is substantially faster, avoiding unnecessary recursive list parsing.
🔬 Measurement: Verify tests run and pass without regressions (visual regression may fail locally due to environment but pure Python unit checks pass).

---
*PR created automatically by Jules for task [16143409100850031689](https://jules.google.com/task/16143409100850031689) started by @andrzejnovak*