### PR TITLE
⚡ Bolt: O(N) single-pass histogram metric extraction and analytic regression

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+
+## 2024-05-30 - O(N) extraction for histogram features
+**Learning:** In `make_style_dict_yaml`, yield and linearity metrics were originally calculated using repeated top-down path lookups (`fitDiag[f"shapes_{fit}/{ch}/{k}"]`) and extracting the `.to_hist()` object multiple times. This is extremely slow for large ROOT files. Moreover, `np.polyfit` is slow for basic 1D regression on small arrays because it runs generalized matrix calculations (SVD).
+**Action:** Replaced key-driven recursive access with a single directory-driven pass. It iterates keys via `ch_dir.keys(cycle=False)`, calls `.to_hist()` exactly once per object, and computes metrics algebraically (manual vectorized slope/intercept regression) in parallel for O(N) complexity instead of O(N * M).

--- a/src/combine_postfits/utils.py
+++ b/src/combine_postfits/utils.py
@@ -154,45 +154,46 @@ def make_style_dict_yaml(fitDiag, cmap="tab10", sort=True, sort_peaky=False):
     # Sorting - yield/peakiness
     def linearity(h):
         _h = h.values()
-        x = np.arange(len(_h))
-        if len(_h) <= 1:
+        n = len(_h)
+        x = np.arange(n, dtype=float)
+        if n <= 1:
             return 0
-        try:
-            coef = np.polyfit(x, _h, 1)
-        except:  # noqa
+
+        sum_x = np.sum(x)
+        sum_y = np.sum(_h)
+        sum_x2 = np.sum(x * x)
+        sum_xy = np.sum(x * _h)
+
+        denominator = n * sum_x2 - sum_x * sum_x
+        if denominator == 0:
             return 0
-        poly1d_fn = np.poly1d(coef)
-        fy = poly1d_fn(x)
+
+        m = (n * sum_xy - sum_x * sum_y) / denominator
+        b = (sum_y - m * sum_x) / n
+
+        fy = m * x + b
         residuals = abs(fy - _h) / np.sqrt(_h)
         return np.sum(np.nan_to_num(residuals, posinf=0, neginf=0))
 
-    yield_dict = {
-        k: sum(
-            [
-                sum(fitDiag[f"shapes_{fit}/{ch}/{k}"].to_hist().values())
-                for fit in avail_fit_types
-                for ch in avail_channels
-                if f"shapes_{fit}/{ch}/{k}" in fitDiag
-                and hasattr(fitDiag[f"shapes_{fit}/{ch}/{k}"], "to_hist")
-                and "total" not in k  # Sum only TH1s, data is black anyway
-            ]
-        )
-        for k in sample_keys
-    }
-    linearity_dict = {
-        k: np.mean(
-            [
-                linearity(fitDiag[f"shapes_{fit}/{ch}/{k}"].to_hist())
-                for fit in avail_fit_types
-                for ch in avail_channels
-                if f"shapes_{fit}/{ch}/{k}" in fitDiag
-                and hasattr(fitDiag[f"shapes_{fit}/{ch}/{k}"], "to_hist")
-                and "total" not in k  # Sum only TH1s, data is black anyway
-            ]
-            + [0]  # pad 0 to prevent mean on empty list
-        )
-        for k in sample_keys
-    }
+    yield_dict = {k: 0.0 for k in sample_keys}
+    lin_sum = {k: 0.0 for k in sample_keys}
+    lin_count = {k: 0 for k in sample_keys}
+
+    for fit in avail_fit_types:
+        for ch in avail_channels:
+            dir_path = f"shapes_{fit}/{ch}"
+            if dir_path in fitDiag:
+                ch_dir = fitDiag[dir_path]
+                for k in ch_dir.keys(cycle=False):
+                    if k in yield_dict and "total" not in k:
+                        obj = ch_dir[k]
+                        if hasattr(obj, "to_hist"):
+                            h = obj.to_hist()
+                            yield_dict[k] += np.sum(h.values())
+                            lin_sum[k] += linearity(h)
+                            lin_count[k] += 1
+
+    linearity_dict = {k: lin_sum[k] / (lin_count[k] + 1) for k in sample_keys}
     sort_score_dicts = {}
     for k, v in yield_dict.items():
         if sort_peaky:


### PR DESCRIPTION
💡 **What**: Refactored the `make_style_dict_yaml` metrics parsing to use a single directory-driven pass over Uproot keys, replacing multiple top-down path lookups. Additionally, swapped out the SVD-based `np.polyfit` in the `linearity` function for a much faster manual analytic 1D linear regression.
🎯 **Why**: The original implementation repeatedly queried `fitDiag` to check for the existence of keys and repeatedly read and deserialized histogram objects (up to 6 times for the same object). `np.polyfit` was also running generalized matrix math for small 1D arrays which caused major overhead.
📊 **Impact**: Reduces object parsing and lookup overhead inside style dictionary generation from O(N * M) to strictly O(N). Algebraic vectorized calculations drastically improve runtime for linearity vs `np.polyfit`.
🔬 **Measurement**: Execute the test suites or benchmark script against heavily-populated `.root` files; execution time inside `make_style_dict_yaml` will drop significantly.

---
*PR created automatically by Jules for task [9233072212081353356](https://jules.google.com/task/9233072212081353356) started by @andrzejnovak*