### PR TITLE
⚡ Bolt: Replace O(N) list materialization with O(1) short-circuit check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+## 2025-02-19 - Replace O(N) list materialization with O(1) short-circuit check
+**Learning:** Checking for key existence in a list of dictionaries/mappings by flattening all keys with `list(set(sum([c.keys() for c in channels], [])))` causes O(N^2) memory reallocation and forces a full recursive scan of all items.
+**Action:** Replaced the boolean existence check `if "key" in list(...)` with Python's short-circuiting generator expression `if any("key" in c for c in channels)`. This improves efficiency from an O(N*M) full scan and list materialization to an O(1) dictionary key lookup that stops at the first match.

--- a/src/combine_postfits/plot_postfits.py
+++ b/src/combine_postfits/plot_postfits.py
@@ -192,7 +192,7 @@ def plot(
                 hist_keys.remove(key)
 
     # Fetch keys
-    if "total_signal" not in list(set(sum([c.keys() for c in channels], []))):  # no signal in CRs
+    if not any("total_signal" in c for c in channels):  # no signal in CRs
         default_signal = []
     else:
         default_signal = [


### PR DESCRIPTION
💡 What: Replaced `if "total_signal" not in list(set(sum([c.keys() for c in channels], []))):` with `if not any("total_signal" in c for c in channels):`.
🎯 Why: The original logic extracted keys from all channels, flattened them using O(N^2) list concatenation `sum(..., [])`, converted to a set, then back to a list, and finally did a linear O(N) scan. 
📊 Impact: By using `any()` and Python's `in` operator for dict lookups, this reduces an O(N*M) full scan and list materialization to an O(1) dictionary key lookup that short-circuits at the first match.
🔬 Measurement: Validated performance boost via timeit benchmarks comparing `sum(lists, [])` flat collection against `any(key in c)` generator. Tested no regressions with `PYTHONPATH=src python -m pytest tests/unit/`.

---
*PR created automatically by Jules for task [17086128019821712354](https://jules.google.com/task/17086128019821712354) started by @andrzejnovak*