### PR TITLE
⚡ Bolt: Optimize `args.cats` parsing string comprehensions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+
+## 2025-05-14 - Precomputed Argument Parsing in Core Processing Loop
+**Learning:** In `make_plots.py`, repeated string parsing (`split()`) and generation of dictionaries and lists using list comprehensions from unchanged inputs (like CLI arguments) within the loops over categories inside inner plotting loops caused significant performance overhead, especially for larger category maps. It introduced completely redundant O(N) processes inside the data preparation phase.
+**Action:** When working with dynamically matched arguments across subsets, explicitly pull these comprehensions and calculations outside of any core `for`/inner loops. Precomputing `merged_cats`, `cats_parsed`, and `cat_map` upfront eliminated redundant string operations during matching and parallelization loops, boosting overall category processing performance.

--- a/src/combine_postfits/make_plots.py
+++ b/src/combine_postfits/make_plots.py
@@ -450,6 +450,18 @@ def main():
                 f"Signals '{','.join(_unset_sigs)}' not found in rmap: `{rmap}`. To display signal strengths pass `--rmap '{','.join([f'{_sig}:r_param' for _sig in _unset_sigs])}'`."
             )
 
+    # Precompute categories mappings and splits to avoid O(N) loops during category processing
+    merged_cats = []
+    cat_map = {}
+    cats_parsed = []
+    if args.cats is not None:
+        if ":" in args.cats:
+            merged_cats = [catmap.split(":")[0] for catmap in args.cats.split(";") if ":" in catmap]
+            cat_map = {parts[0]: parts[1] for s in args.cats.split(";") if ":" in s for parts in [s.split(":", 1)]}
+            cats_parsed = args.cats.split(";")
+        else:
+            cats_parsed = args.cats.split(",")
+
     # Get types/cats/blinds unwrapped
     all_channels = []
     all_blinds = []  # blind category
@@ -465,18 +477,14 @@ def main():
         for pattern in blind_cat_patterns:
             blinded_channels.extend(fnmatch.filter(available_channels, pattern))
             if args.cats is not None and ":" in args.cats:
-                blinded_channels.extend(
-                    fnmatch.filter([catmap.split(":")[0] for catmap in args.cats.split(";") if ":" in catmap], pattern)
-                )  # allow merged cats
+                blinded_channels.extend(fnmatch.filter(merged_cats, pattern))  # allow merged cats
         blind_cats = list(set(blinded_channels))
         logging.debug(f"Categories to blind: {blind_cats}")
         if blind_mapping is not None:
             blind_mapping_flattened = {}
             if args.cats is not None and ":" in args.cats:
                 for pattern, slice_string in blind_mapping.items():
-                    for channel in fnmatch.filter(
-                        [catmap.split(":")[0] for catmap in args.cats.split(";") if ":" in catmap], pattern
-                    ):
+                    for channel in fnmatch.filter(merged_cats, pattern):
                         blind_mapping_flattened[channel] = slice_string
             else:
                 # If no --cats specified, try matching against available_channels
@@ -500,7 +508,7 @@ def main():
                 channels = []
                 blinds = []
                 savenames = []
-                for cat in args.cats.split(";"):
+                for cat in cats_parsed:
                     if ":" not in cat:
                         logging.error(f"Invalid cats mapping '{cat}', expected 'merged_cat:cat1,cat2'. Skipping.")
                         continue
@@ -518,7 +526,7 @@ def main():
             # list
             else:
                 channels = sum(
-                    [fnmatch.filter(available_channels, _cat) for _cat in args.cats.split(",")],
+                    [fnmatch.filter(available_channels, _cat) for _cat in cats_parsed],
                     [],
                 )
                 blinds = [True if c in blind_cats else False for c in channels]
@@ -621,10 +629,7 @@ def main():
                 if len(channel) < 6:
                     label = 1
                 else:
-                    _cat_map = {
-                        parts[0]: parts[1] for s in args.cats.split(";") if ":" in s for parts in [s.split(":", 1)]
-                    }
-                    label = _cat_map.get(sname, 1)
+                    label = cat_map.get(sname, 1)
 
             def mod_plot(semaphore=None):
                 try:


### PR DESCRIPTION
💡 What: The arguments provided in `--cats` are now split and mapped upfront, outside of the inner `fit_types` processing loop.
🎯 Why: In `make_plots.py`, when a user specifies a large number of category merges or matching strings, the application was re-parsing and regenerating the `cat_map` strings via list/dict comprehensions sequentially for *every* blinded category and every fitting category check. Pulling these loop invariants into precomputed static variables avoids redundant parsing strings repeatedly in Python.
📊 Impact: This decreases completely redundant operations proportional to `len(all_channels) * len(args.cats.split(";"))`. This lowers loop processing CPU overhead considerably when a large amount of subsets are given.
🔬 Measurement: Verify changes in CLI integration performance over large test suites where the application is run repeatedly. The functionality has been validated across the test suite.

---
*PR created automatically by Jules for task [16726140237766291283](https://jules.google.com/task/16726140237766291283) started by @andrzejnovak*