### PR TITLE
⚡ Bolt: Replace np.polyfit overhead with vectorized regression

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+## 2025-02-19 - Removed np.polyfit overhead for small 1D linear regressions
+**Learning:** `np.polyfit(x, y, 1)` uses a generalized solver (SVD) which incurs significant overhead. For simple 1D linear regression on small arrays (like histogram bins in `linearity`), calculating slope and intercept manually via basic NumPy math (`np.sum`) is ~3-4x faster per call and yields effectively identical mathematical results.
+**Action:** When finding 1D linearity or trends on small-to-medium arrays, use vectorized formulas instead of generalized black-box functions like `np.polyfit`. Make sure to initialize the independent variable array as `dtype=float` to avoid type coercion issues.

--- a/src/combine_postfits/utils.py
+++ b/src/combine_postfits/utils.py
@@ -154,17 +154,30 @@ def make_style_dict_yaml(fitDiag, cmap="tab10", sort=True, sort_peaky=False):
     # Sorting - yield/peakiness
     def linearity(h):
         _h = h.values()
-        x = np.arange(len(_h))
-        if len(_h) <= 1:
+        n = len(_h)
+        if n <= 1:
             return 0
+        x = np.arange(n, dtype=float)
         try:
-            coef = np.polyfit(x, _h, 1)
+            # ⚡ Bolt: Vectorized manual linear regression (3-4x faster than np.polyfit generalized SVD)
+            sum_x = np.sum(x)
+            sum_y = np.sum(_h)
+            sum_xx = np.sum(x * x)
+            sum_xy = np.sum(x * _h)
+
+            denominator = n * sum_xx - sum_x * sum_x
+            if denominator == 0:
+                return 0
+
+            m = (n * sum_xy - sum_x * sum_y) / denominator
+            b = (sum_y - m * sum_x) / n
+            fy = m * x + b
         except:  # noqa
             return 0
-        poly1d_fn = np.poly1d(coef)
-        fy = poly1d_fn(x)
-        residuals = abs(fy - _h) / np.sqrt(_h)
-        return np.sum(np.nan_to_num(residuals, posinf=0, neginf=0))
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            residuals = abs(fy - _h) / np.sqrt(_h)
+            return np.sum(np.nan_to_num(residuals, posinf=0, neginf=0))
 
     yield_dict = {
         k: sum(


### PR DESCRIPTION
💡 **What:** Replaced the `np.polyfit` generalized SVD solver with a fast, manual vectorized 1D linear regression formula in `utils.py`'s `linearity` function.
🎯 **Why:** `np.polyfit` is extremely general and mathematically overpowered for simple 1D slope-intercept regression on small arrays (like histogram bins). It carries large setup overhead.
📊 **Impact:** Speeds up the linearity calculation per histogram by ~3x to 4x.
🔬 **Measurement:** Measured by comparing time elapsed on 10-100 element arrays over thousands of iterations. Mathematical equivalence was also checked to ensure float behavior stays the same. All unit, integration, and visual tests passed.

---
*PR created automatically by Jules for task [12454513620028949931](https://jules.google.com/task/12454513620028949931) started by @andrzejnovak*