### PR TITLE
⚡ Bolt: Optimize ROOT TH2 bin content extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-19 - Removed redundant O(n) scan in inner loop
 **Learning:** `np.max([np.max(h.values()) for h in hist_dict.values()])` was being called inside a nested helper function (`hist_dict_fcn`) that executed multiple times for each histogram plotted. Profiling showed this dominated execution time because it was calculating the global max recursively instead of caching it once.
 **Action:** Always look for invariants in nested loops and inner functions. Moved the `_max_value_global` calculation outside the `hist_dict_fcn` to speed up plotting. Remember NOT to use `functools.lru_cache` for `hist_dict_fcn` since it returns deepcopies that are mutated by the caller.
+## 2024-06-26 - ROOT Histogram Bulk Extraction Optimization
+**Learning:** PyROOT wrapper calls like `GetBinContent` inside nested Python loops incur severe overhead due to boundary crossings between Python and C++.
+**Action:** Always prefer bulk array extraction techniques using `np.ndarray(..., buffer=h2.GetArray())` and determine the underlying precision dynamically (e.g., `h2.ClassName()` -> `np.float64`/`np.float32`/`np.int32`). This optimization is critical for reducing plot generation time on dense multi-bin correlation matrices (e.g., `plot_cov.py`).

--- a/src/combine_postfits/plot_cov.py
+++ b/src/combine_postfits/plot_cov.py
@@ -34,9 +34,11 @@ def plot_cov(
     y_labels = [h2.GetYaxis().GetBinLabel(i) for i in range(1, y_bins + 1)]
     x_labels = [h2.GetXaxis().GetBinLabel(i) for i in range(1, x_bins + 1)]
     hist_2d = hist.new.StrCat(x_labels, label="").StrCat(y_labels, label="").Double()
-    for i in range(0, x_bins):
-        for j in range(0, y_bins):
-            hist_2d.view()[i, j] = h2.GetBinContent(i + 1, j + 1)
+
+    # ⚡ Bolt: Bulk extract ROOT histogram data to avoid costly Python-to-C++ loop calls
+    dtype_map = {"TH2D": np.float64, "TH2F": np.float32, "TH2I": np.int32}
+    _dtype = dtype_map.get(h2.ClassName(), np.float64)
+    hist_2d.view()[:] = np.ndarray((y_bins + 2, x_bins + 2), dtype=_dtype, buffer=h2.GetArray())[1:-1, 1:-1].T
 
     keys = x_labels
     if isinstance(include, str) or isinstance(include, list):


### PR DESCRIPTION
💡 **What:**
Replaced nested O(N²) Python loops in `plot_cov.py` that call `h2.GetBinContent(i+1, j+1)` with a single bulk numpy buffer extraction using `np.ndarray((y_bins+2, x_bins+2), dtype=_dtype, buffer=h2.GetArray())[1:-1, 1:-1].T`.

🎯 **Why:**
PyROOT wrapper calls like `GetBinContent` inside Python loops incur massive performance penalties due to constant Python-to-C++ boundary crossings. Vectorized bulk array extraction eliminates this overhead completely for large covariance matrices.

📊 **Impact:**
Reduces the data extraction time for TH2 objects into scikit-hep structures dramatically. This is an algorithmic change from O(N²) Python API calls to O(1) Python API call wrapping O(N) C++ native copy/cast, producing a significant speedup on large N nuisance matrices.

🔬 **Measurement:**
No logical changes. Validated by ensuring all `pytest` and visual regression tests still pass perfectly and linting (`pixi run lint`) is fully clean.

---
*PR created automatically by Jules for task [13044940935890971178](https://jules.google.com/task/13044940935890971178) started by @andrzejnovak*