### PR TITLE
chore: align ruff target-version and deps with the py3.11 baseline

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2243,8 +2243,8 @@ packages:
   timestamp: 1733218222191
 - pypi: ./
   name: combine-postfits
-  version: 0.1.2.dev9+gf98005814.d20260701
-  sha256: d4917138f2c67e23967c4e4fe4ff36b2ca7be34a68ba9ae43332cd6b0a0fd0aa
+  version: 0.1.2.dev6+ga9733dd4a
+  sha256: 7440e39686d103c66e018bfb57d0a2a92def1972fda595e0f8251db99a3a0642
   requires_dist:
   - hist
   - matplotlib>=3.11
@@ -2255,7 +2255,6 @@ packages:
   - rich-argparse-plus
   - scipy
   - typeguard
-  - typing-extensions
   - uproot
   - pytest ; extra == 'all'
   - pytest-image-diff ; extra == 'all'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 ]
 
 dependencies = [
-  "typing_extensions",
   "typeguard",
   "rich",
   "rich-argparse-plus",
@@ -92,7 +91,7 @@ markers = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py311"
 exclude = ["**/_version.py"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Part of #149

This PR aligns two `pyproject.toml` tooling/metadata settings with the project's declared `>=3.11` Python baseline: it bumps the ruff `target-version` and removes an unused runtime dependency. No source code changes.

## Findings fixed

- [x] **[LOW/modernization]** `[tool.ruff] target-version = "py39"` contradicted `requires-python = ">=3.11"` (pyproject.toml:95). Set to `"py311"`. Verified this does not introduce new lint errors: `ruff check .` on the whole repo is clean (only `E`, `F`, `W`, `I` rules are selected — no pyupgrade `UP` rules enabled, so the bump is lint-neutral today but corrects the declared baseline for when `UP` is enabled later).
- [x] **[LOW/modernization]** Unused `typing_extensions` hard runtime dependency (pyproject.toml:42). Verified via `grep -rn "typing_extensions" src/ tests/` — no hits anywhere in the codebase. Removed from `[project].dependencies`; its typing backports are already in the stdlib on Python >=3.11.

No deferred findings.

## Visual baseline impact

None — tooling/metadata only change, no source code touched.

## Testing

- `ruff check .` (whole repo, post target-version bump): `All checks passed!`
- `PYTHONPATH=src pytest tests/unit tests/integration -m "not root and not visual" -q`: `91 passed, 16 deselected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSttUPmnsfpZkqQQpCwraJ
