### PR TITLE
fix(make_plots): blind-data safety in list mode + multiprocessing robustness

### DIFF
--- a/src/combine_postfits/make_plots.py
+++ b/src/combine_postfits/make_plots.py
@@ -4,12 +4,14 @@ import importlib.util
 import logging
 import sys
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from multiprocessing import Process, Semaphore
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import matplotlib
+import matplotlib.pyplot as plt
 import mplhep as hep
 import numpy as np
 import uproot
@@ -52,8 +54,6 @@ def time_check(progress: Progress, procs: list[Process], limit: int = 5) -> None
         logging.error(f"Terminating remaining plot processes: {[p.name for p in remaining_procs]}")
         for p in remaining_procs:
             p.terminate()
-        import sys
-
         sys.exit()
 
 
@@ -71,8 +71,10 @@ def sci_notation(number: float, sig_fig: int = 1, no_zero: bool = False) -> str:
 
 
 def get_digits(number: float) -> tuple[int, int]:
-    """Return the number of digits before and after the decimal point."""
-    before, _, after = np.round(number, 10).astype(str).partition(".")
+    """Return the number of digits before and after the decimal point (magnitude only)."""
+    # Use abs() so a leading '-' is not counted as a digit, and format_float_positional to
+    # avoid scientific-notation strings (e.g. '1e-05') that would corrupt the digit counts.
+    before, _, after = np.format_float_positional(abs(np.round(number, 10)), trim="-").partition(".")
     return len(before), len(after)
 
 
@@ -135,9 +137,13 @@ def generate_plot_tasks(
         # We flatten the mapping: {channel: "range_string"}
         blind_mapping_flattened = {}
         if args.blind_data:
-            target_channels = (
-                [catmap.split(":")[0] for catmap in args.cats.split(";")] if args.cats else available_channels
-            )
+            # Blind-data patterns are matched against the names that become each plot's savename:
+            # merged-group (mcat) names in mapping mode ("name:pats;..."), otherwise the actual
+            # channel names (list mode "cat1,cat2" and implicit-all both plot real channels).
+            if args.cats and ":" in args.cats:
+                target_channels = [catmap.split(":")[0] for catmap in args.cats.split(";")]
+            else:
+                target_channels = available_channels
             for pattern, slice_string in blind_mapping.items():
                 for channel in fnmatch.filter(target_channels, pattern):
                     blind_mapping_flattened[channel] = slice_string
@@ -185,7 +191,7 @@ def generate_plot_tasks(
                         channels=resolved_cats,
                         blind=(mcat in blind_cats),
                         savename=mcat,
-                        label=args.catlabels if args.catlabels and ";" not in args.catlabels else mcat,
+                        label=None,  # Resolved in main() (supports ';'-separated --catlabels per group)
                         blind_range=blind_mapping_flattened.get(mcat),
                     )
             else:
@@ -214,8 +220,21 @@ def process_plot(
     out_dir: Path,
     format_list: list[str],
 ) -> None:
-    """Process a single plot task (worker function)."""
+    """Process a single plot task (worker function).
+
+    ``fd``/``rfd`` are the parent's open handles, reused directly in the serial path. In the
+    multiprocessing path they are passed as ``None`` and each worker opens its own handles from
+    ``args.input``: a ROOT ``TFile``/uproot directory must not be shared across processes (a forked
+    child would share the file offset, and the handles are not picklable under spawn/forkserver).
+    """
+    fig = None
+    own_handles = False
     try:
+        if fd is None:
+            fd = uproot.open(args.input)
+            own_handles = True
+            if ROOT_AVAILABLE and not args.noroot:
+                rfd = r.TFile.Open(args.input)
         config = plot_postfits.PlotConfig(
             fit_type=task.fittype,
             cats=task.channels,
@@ -283,6 +302,12 @@ def process_plot(
                 # transparent=True,
             )
     finally:
+        if fig is not None:
+            plt.close(fig)  # Release the figure (serial path reuses pyplot's global figure manager)
+        if own_handles:
+            fd.close()
+            if rfd:
+                rfd.Close()
         if semaphore is not None:
             semaphore.release()
 
@@ -624,15 +649,12 @@ def main():
 
         # Generate Tasks
         # We iterate over tasks yielded by the generator
-        _procs: list[Process] = []
-        n_tasks = 0
         all_tasks = []  # Store tasks to allow for label parsing and progress bar total
         for task in generate_plot_tasks(args, fit_types, fd):
-            n_tasks += 1
             all_tasks.append(task)
             logging.debug(f"Processing task: {task}")
 
-        if n_tasks == 0:
+        if not all_tasks:
             logging.warning("No plotting tasks generated. Check your --cats or --fit options.")
             sys.exit(0)
 
@@ -646,6 +668,20 @@ def main():
             else:
                 logging.warning(
                     f"Number of labels ({len(labels_list)}) does not match number of plots ({len(all_tasks)}). Ignoring labels."
+                )
+        # Label parsing for mapping mode: ';'-separated --catlabels map to the merged groups by name.
+        elif args.catlabels is not None and args.cats and ":" in args.cats:
+            labels_list = args.catlabels.split(";")
+            group_names = [group.split(":", 1)[0] for group in args.cats.split(";") if ":" in group]
+            if len(labels_list) == len(group_names):
+                label_by_group = dict(zip(group_names, labels_list))
+                for task in all_tasks:
+                    if task.savename in label_by_group:
+                        task.label = label_by_group[task.savename]
+            else:
+                logging.warning(
+                    f"Number of labels ({len(labels_list)}) does not match number of merged groups "
+                    f"({len(group_names)}). Ignoring labels."
                 )
 
         # Check for overlaps
@@ -692,7 +728,10 @@ def main():
                 sys.exit("Aborted by user due to overlapping categories.")
 
         # Process Tasks
-        _procs = []
+        _procs: list[Process] = []  # currently-live worker processes
+        _finished: list[Process] = []  # completed workers, kept to inspect exit codes
+        completed = 0
+        failed: list[str] = []
         with Progress(
             TextColumn("[progress.description]{task.description}"),
             SpinnerColumn(),
@@ -716,13 +755,23 @@ def main():
                 task.label = "\n".join(str(task.label).split(r"\n"))
 
                 if args.multiprocessing > 0:
+                    # Block until a slot frees; the Semaphore already bounds concurrency, so no
+                    # artificial time.sleep() throttle is needed here.
                     semaphore.acquire()
+                    # Reap finished workers so the live-process scans stay O(live), not O(total).
+                    for done in [p for p in _procs if not p.is_alive()]:
+                        done.join()
+                        _finished.append(done)
+                        _procs.remove(done)
+                        completed += 1
+                    # Pass None handles: each worker opens its own fd/rfd from args.input (a ROOT
+                    # TFile/uproot directory must not be shared across processes); see process_plot.
                     p = Process(
                         target=process_plot,
                         args=(
                             semaphore,
-                            fd,
-                            rfd,
+                            None,
+                            None,
                             task,
                             style,
                             rmap,
@@ -734,14 +783,11 @@ def main():
                     )
                     _procs.append(p)
                     p.start()
-                    time.sleep(0.1)
-
-                    n_running = sum([p.is_alive() for p in _procs])
                     progress.update(
                         prog_plotting,
-                        completed=len(_procs) - n_running,
+                        completed=completed,
                         refresh=True,
-                        description=prog_str_fmt.format(n_running),
+                        description=prog_str_fmt.format(len(_procs)),
                     )
                     time_check(progress, _procs, 6)
                 else:
@@ -758,24 +804,35 @@ def main():
                     )
                     progress.update(prog_plotting, advance=1, refresh=True)
             if args.multiprocessing > 0:
-                while sum([p.is_alive() for p in _procs]) > 0:
-                    n_running = sum([p.is_alive() for p in _procs])
+                # Drain remaining workers, polling so the time_check watchdog can still fire.
+                while _procs:
+                    for done in [p for p in _procs if not p.is_alive()]:
+                        done.join()
+                        _finished.append(done)
+                        _procs.remove(done)
+                        completed += 1
                     progress.update(
                         prog_plotting,
-                        completed=len(_procs) - n_running,
+                        completed=completed,
                         refresh=True,
-                        description=prog_str_fmt.format(n_running),
+                        description=prog_str_fmt.format(len(_procs)),
                     )
-                    time.sleep(0.1)
-
-                    time_check(progress, _procs, 6)
+                    if _procs:
+                        time_check(progress, _procs, 6)
+                        time.sleep(0.1)
+                # Surface worker failures instead of silently counting a crashed worker as done.
+                failed = [p.name for p in _finished if p.exitcode]
+                if failed:
+                    logging.error(f"{len(failed)} plotting worker(s) failed (see tracebacks above): {failed}")
             progress.update(
                 prog_plotting,
-                completed=n_tasks,
-                total=n_tasks,
+                completed=len(all_tasks),
+                total=len(all_tasks),
                 refresh=True,
                 description=prog_str_fmt.format(0),
             )
+        if failed:
+            sys.exit(1)
 
     finally:
         fd.close()


### PR DESCRIPTION
Part of #149

Fixes verified code-review findings in `src/combine_postfits/make_plots.py`. The headline fix is a **data-safety bug**: in list-mode `--cats cat1,cat2` (comma, no colon), the `--blind-data` target channels were parsed as a `name:pats` mapping, producing the bogus single token `"cat1,cat2"` that matches no real channel — so requested blinding ranges were silently dropped and real data was drawn unblinded. Target-channel resolution now branches on whether `:` is present in `--cats`, matching mapping-mode group names or the actual channel names as appropriate. The remaining changes harden the multiprocessing orchestration and clean up minor issues. Changes are minimal and localized; the only fix that can alter rendered pixels is the `get_digits` sign fix (see Visual baseline impact).

### Findings fixed (9/9, 0 deferred)

**HIGH**
- [x] List-mode `--cats` silently dropped `--blind-data` ranges → data shown unblinded. `target_channels` now resolves to `available_channels` in list/implicit-all mode and to merged-group (mcat) names only in mapping mode.

**MEDIUM**
- [x] `;`-separated `--catlabels` ignored in category-merging (mapping) mode. Labels are now zipped to merged groups by name (with a length-mismatch warning); a single non-matching label no longer mislabels every group. The generator defers the label to `main()` (`label=None`).
- [x] Serial mode (`-p 0`) never closed figures (memory leak + matplotlib >20-figures warning). `process_plot` now calls `plt.close(fig)` in a `finally`.
- [x] ROOT `TFile`/uproot handle shared across forked workers (corruption risk; crash under spawn/forkserver). Workers are now launched with `None` handles and open their own from `args.input`; the serial path still reuses the parent's handles. This also makes all `Process` args picklable, so `-p N` works under non-fork start methods.
- [x] Worker failures were swallowed and counted as completed. After joining, `p.exitcode` is inspected; failed task names are logged and the run exits non-zero.
- [x] Per-launch `time.sleep(0.1)` throttle + O(n^2) `is_alive()` polling. The fixed launch throttle is removed (the `Semaphore` already bounds concurrency); finished workers are reaped so scans stay O(live) and the running count is computed once per iteration.

**LOW**
- [x] `get_digits` counted the minus sign as a leading digit (and mishandled exponential forms) → premature scientific-notation y-ticks. Now counts magnitude only via `abs()` + `np.format_float_positional(..., trim="-")`.
- [x] Dead/redundant local state removed: the pre-declaration of `_procs`, the redundant `n_tasks` counter (now `len(all_tasks)`), and the duplicate local `import sys` in `time_check`.
- [x] `typing.Iterator` (deprecated alias) replaced with `collections.abc.Iterator`.

### Visual baseline impact
Most changes are pure orchestration and do not alter rendered output. Two things can:
- **`get_digits` sign fix** changes *which formatter* is applied to the main y-axis for categories whose stack axis has negative ticks in the hundreds (e.g. `-100`): previously the `-` inflated the leading-digit count to 4 and flipped the axis into `$10^{2}$`-style scientific notation even though the magnitude is only 3 digits; now such axes render with plain ticks. Categories without negative-hundreds ticks are unaffected (the `>3` decision is unchanged for those). If any baseline plot has such an axis, baselines will need regeneration (`pixi run generate-baselines`).
- **Blind-data list-mode fix** changes *which data is drawn* for affected categories: with `--cats cat1,cat2 --blind-data cat1:...`, the requested range is now actually blinded (previously it was not). This is the intended safety fix; any baseline generated with an affected list-mode `--blind-data` invocation would change.

### Testing
`PYTHONPATH=src python -m pytest tests/unit tests/integration -m "not root and not visual" -q` → **91 passed, 16 deselected** (matches the pre-change baseline; no regressions). Additionally verified out-of-band: list/glob/mapping/implicit `--blind-data` resolution, mapping-mode `--catlabels` assignment and mismatch warning, `-p N` multiprocessing rendering, and non-zero exit on a crashing worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSttUPmnsfpZkqQQpCwraJ
